### PR TITLE
Fix FTS incomplete result and implement enable/disable exact search

### DIFF
--- a/dindex_store/fulltext_index_duckdb.py
+++ b/dindex_store/fulltext_index_duckdb.py
@@ -19,7 +19,6 @@ class FTSIndexDuckDB(FullTextSearchIndex):
         self.index_column = config["fts_index_column"]
 
         if not load:
-            # fts_schema_path = Path(os.getcwd() + "/" + config["fts_schema_name"]).absolute()
             fts_schema_path = Path(config['ver_base_path'] / config['fts_schema_name']).absolute()
             if not fts_schema_path.is_file():
                 raise ValueError("The path to fts_schema does not exist, or is not a file")
@@ -57,18 +56,6 @@ class FTSIndexDuckDB(FullTextSearchIndex):
         query = f"PRAGMA create_fts_index('{table_name}', '{index_column}', '*', stopwords='none')"
         self.conn.execute(query)
 
-        # prepare_query = f"""
-        #     PREPARE fts_query AS (
-        #         WITH scored_docs AS (
-        #             SELECT *, fts_main_{table_name}.match_bm25(profile_id, ?) AS score FROM {table_name})
-        #         SELECT profile_id, score
-        #         FROM scored_docs
-        #         WHERE score IS NOT NULL
-        #         ORDER BY score DESC
-        #         LIMIT 100)
-        #     """
-        # self.conn.execute(prepare_query)
-
     def insert(self, profile_id, dbName, path, sourceName, columnName, data) -> bool:
         try:
             fts_data_table = self.conn.table(self.table_name)
@@ -82,13 +69,11 @@ class FTSIndexDuckDB(FullTextSearchIndex):
     # Query Methods
 
     def fts_query(self, keyword, search_domain, max_results, exact_search) -> List:
-        # TODO: switch between exact/approx search ("exact_search")
-
         # FIXME: translate search_domain into a field; here defaulting to data
         search_domain = 'data'
 
         query = f"""WITH scored_docs AS (
-                SELECT *, fts_main_{self.table_name}.match_bm25(data, '{keyword}', fields := '{search_domain}', conjunctive := 1) 
+                SELECT *, fts_main_{self.table_name}.match_bm25(data, '{keyword}', fields := '{search_domain}', conjunctive := {1 if exact_search else 0}) 
                 AS score FROM {self.table_name})
             SELECT DISTINCT ON (profile_id) profile_id, dbname, path, sourcename, columnname, score
             FROM scored_docs

--- a/dindex_store/fulltext_index_duckdb.py
+++ b/dindex_store/fulltext_index_duckdb.py
@@ -54,7 +54,7 @@ class FTSIndexDuckDB(FullTextSearchIndex):
                 print(f"error when removing an existing fts index: {ce}")
 
         # Create fts index over all, *, attributes
-        query = f"PRAGMA create_fts_index('{table_name}', '{index_column}', '*', stopwords='english')"
+        query = f"PRAGMA create_fts_index('{table_name}', '{index_column}', '*', stopwords='none')"
         self.conn.execute(query)
 
         # prepare_query = f"""


### PR DESCRIPTION
This PR will:
1. Fix FTS problem in #59 (explanation below).
2. Implement enable/disable exact search in `fulltext_index_duckdb.py`'s `fts_query` function.

With `stopwords='english'`, DuckDB's FTS index will remove stopwords before storing the searchable data. But, when the client send a keyword to find, the stopwords in the keyword is not removed. For example, "University of Chicago" will be stored as "University Chicago" (the actual implementation can be a bit different), but querying "University of Chicago" will not be read as "University Chicago" and FTS will return empty result. On the contrary, with `stopwords='none'`, "University of Chicago" will still be stored as "University of Chicago" and querying "University Chicago" will still find "University of Chicago".